### PR TITLE
Updating to Hadoop from CDH 4.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.urbanairship</groupId>
   <artifactId>hbackup</artifactId>
-  <version>0.10.2-SNAPSHOT</version>
+  <version>0.11.0-SNAPSHOT</version>
 
   <name>hbackup</name>
   <url>http://urbanairship.com</url>
@@ -114,7 +114,17 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-core</artifactId>
-      <version>0.20.2-cdh3u2</version>
+      <version>2.0.0-mr1-cdh4.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <version>2.0.0-cdh4.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <version>2.0.0-cdh4.4.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -150,8 +160,20 @@
    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-test</artifactId>
-      <version>0.20.2-cdh3u2</version>
+      <version>2.0.0-mr1-cdh4.4.0</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <version>2.0.0-cdh4.4.0</version>
+      <classifier>tests</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <version>2.0.0-cdh4.4.0</version>
+      <classifier>tests</classifier>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Modified HdfsTest to use the new MiniDFSCluster builder pattern.

There is a terrible, awful hack in setupHdfsClusters. For some unknown reason,
the first write to HDFS fails under this version of MiniDFSCluster. All
subsequent writes work fine. It does not create the proper folders on the
filesystem on the first write, but they are created on the second write.
